### PR TITLE
create APACHE_ROOT dir

### DIFF
--- a/Vagrant.bootstrap.sh
+++ b/Vagrant.bootstrap.sh
@@ -46,6 +46,9 @@ APACHE_ROOT="/var/www"
 APP_PATH="$APACHE_ROOT/utn-devops-app/"
 
 # descargo la app del repositorio
+if [ ! -d  $APACHE_ROOT]; then
+	sudo mkdir $APACHE_ROOT
+fi
 cd $APACHE_ROOT
 sudo git clone https://github.com/Fichen/utn-devops-app.git
 cd $APP_PATH


### PR DESCRIPTION
En caso de que el directorio "/var/www" no exista, el "[cd](https://github.com/Fichen/utn-devops/blob/0f0f96a5e10b7647dddef08a5b0316289b743e45/Vagrant.bootstrap.sh#L49)" falla y se clona el repositorio en el directorio "[/swapdir](https://github.com/Fichen/utn-devops/blob/0f0f96a5e10b7647dddef08a5b0316289b743e45/Vagrant.bootstrap.sh#L31)".

Se agrega un chequeo y creado de directorio.
